### PR TITLE
Add --merge flag to makemigrations in deploy.yml

### DIFF
--- a/{{cookiecutter.project_slug}}/ansible/deploy.yml
+++ b/{{cookiecutter.project_slug}}/ansible/deploy.yml
@@ -37,7 +37,7 @@
 
     - name: Run Django makemigrations
       shell: . {{ virtualenvs_dir }}/{{ project_name }}-env/bin/activate
-            && python manage.py makemigrations --noinput --settings={{ project_name }}.settings.production
+            && python manage.py makemigrations --merge --noinput --settings={{ project_name }}.settings.production
       args:
            chdir: "{{ sites_dir }}/{{ project_name }}"
       tags:


### PR DESCRIPTION
Added the missing --merge flag on the django makemigrations command in the deploy.yml Ansible script.  

Ran into an issue today with remote deployment and the makemigrations --merge flag resolved this error: 
CommandError: Conflicting migrations detected; multiple leaf nodes in the migration graph.

Should save someone a bit of troubelshooting :)