### PR TITLE
AMP: convert img and iframe tags to amp version including richtext fields

### DIFF
--- a/{{cookiecutter.project_slug}}/blog/templates/blog/blog_page_amp.html
+++ b/{{cookiecutter.project_slug}}/blog/templates/blog/blog_page_amp.html
@@ -23,29 +23,9 @@
 {% block content %}
 <div id="content" class="row">
   <div class="medium-12 columns" role="content">
-    {% if self.body %}
     <article>
-      {% for block in self.body %}
-      {% if block.block_type == 'heading' %}
-
-      <h1>{{ block.value }}</h1>
-
-      {% elif block.block_type == 'image' %}
-      {% image block.value fill-800x400 as img %}
-      <div class="halfwidth">
-        <amp-img src="{{ img.url }}" width="{{ img.width }}" height="{{ img.height }}" layout="responsive">
-        </amp-img>
-      </div>
-
-      {% else %}
-      <section class="block-{{ block.block_type }}">
-        {% include_block block %}
-      </section>
-
-      {% endif %}
-      {% endfor %}
+      {{ body_html }}
     </article>
-    {% endif %}
   </div>
 </div>
 {% endblock %}{% endraw %}

--- a/{{cookiecutter.project_slug}}/pages/templates/amp_base.html
+++ b/{{cookiecutter.project_slug}}/pages/templates/amp_base.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
     {% block schema %}{% endblock %}
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
 


### PR DESCRIPTION
Issue #644

@chrisdev The `context` only include the `image` id and also ` embeds module` is called in the template. Therefore have to change the rendered `html` using `BS4`.